### PR TITLE
Advocates Pagination - Client

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,14 @@ import { AdvocateTable } from "../components/advocates/AdvocateTable";
 
 export default function Home() {
   return (
-    <main className="container mx-auto p-6">
-      <div className="mb-8">
+    <main className="h-screen flex flex-col p-6">
+      <div className="mb-6 flex-shrink-0">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">Solace Advocates Dashboard</h1>
         <p className="text-gray-600">Manage and search through our network of legal advocates</p>
       </div>
       
-      <div className="grid gap-6">
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="flex-1 min-h-0">
+        <div className="bg-white rounded-lg shadow-sm border p-6 h-full">
           <AdvocateTable />
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,9 @@ export default function Home() {
     <main className="h-screen flex flex-col p-6">
       <div className="mb-6 flex-shrink-0">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">Solace Advocates Dashboard</h1>
-        <p className="text-gray-600">Manage and search through our network of legal advocates</p>
+        <p className="text-gray-600">Manage and search through our network of healthcare advocates</p>
       </div>
-      
+
       <div className="flex-1 min-h-0">
         <div className="bg-white rounded-lg shadow-sm border p-6 h-full">
           <AdvocateTable />

--- a/src/components/shared/DataTable.tsx
+++ b/src/components/shared/DataTable.tsx
@@ -4,83 +4,65 @@ import React from "react";
 import {
     useReactTable,
     getCoreRowModel,
-    getFilteredRowModel,
     getSortedRowModel,
     flexRender,
     ColumnDef,
     SortingState,
-    ColumnFiltersState,
 } from "@tanstack/react-table";
 import { useState } from "react";
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
     data: TData[];
-    searchKey?: string;
-    searchPlaceholder?: string;
     onRowClick?: (row: TData) => void;
     className?: string;
+    // Infinite scroll support
+    loadMoreRef?: React.RefObject<HTMLDivElement>;
+    isLoadingMore?: boolean;
+    hasMore?: boolean;
+    noMoreMessage?: string;
 }
 
 export function DataTable<TData, TValue>({
     columns,
     data,
-    searchKey,
-    searchPlaceholder = "Search...",
     onRowClick,
     className = "",
+    loadMoreRef,
+    isLoadingMore,
+    hasMore,
+    noMoreMessage = "No more results to load",
 }: DataTableProps<TData, TValue>) {
     const [sorting, setSorting] = useState<SortingState>([]);
-    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-    const [globalFilter, setGlobalFilter] = useState("");
 
     const table = useReactTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
-        getFilteredRowModel: getFilteredRowModel(),
         getSortedRowModel: getSortedRowModel(),
         onSortingChange: setSorting,
-        onColumnFiltersChange: setColumnFilters,
-        onGlobalFilterChange: setGlobalFilter,
         state: {
             sorting,
-            columnFilters,
-            globalFilter,
         },
     });
 
     return (
-        <div className={className}>
-            {/* Search Input */}
-            {searchKey && (
-                <div className="mb-4">
-                    <input
-                        placeholder={searchPlaceholder}
-                        value={globalFilter ?? ""}
-                        onChange={(event) => setGlobalFilter(event.target.value)}
-                        className="border border-gray-300 rounded px-3 py-2 w-full max-w-sm"
-                    />
-                </div>
-            )}
-
-            {/* Table */}
-            <div className="border border-gray-200 rounded-lg overflow-hidden">
-                <table className="w-full">
-                    <thead className="bg-gray-50">
+        <div className={`flex flex-col h-full ${className}`}>
+            {/* Scrollable Table Container */}
+            <div className="flex-1 overflow-auto border border-gray-200 rounded-lg">
+                <table className="w-full min-w-max">
+                    <thead className="bg-gray-50 sticky top-0 z-10">
                         {table.getHeaderGroups().map((headerGroup) => (
                             <tr key={headerGroup.id}>
                                 {headerGroup.headers.map((header) => (
                                     <th
                                         key={header.id}
-                                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
                                     >
-                                        {header.isPlaceholder
-                                            ? null
-                                            : flexRender(
-                                                header.column.columnDef.header,
-                                                header.getContext()
-                                            )}
+                                        {header.isPlaceholder ? null : flexRender(
+                                            header.column.columnDef.header,
+                                            header.getContext()
+                                        )}
                                     </th>
                                 ))}
                             </tr>
@@ -115,6 +97,21 @@ export function DataTable<TData, TValue>({
                                     className="h-24 text-center text-gray-500"
                                 >
                                     No results.
+                                </td>
+                            </tr>
+                        )}
+                        {/* Infinite Scroll Trigger */}
+                        {loadMoreRef && (
+                            <tr>
+                                <td colSpan={columns.length} className="p-0">
+                                    <div ref={loadMoreRef} className="flex justify-center py-4">
+                                        {isLoadingMore && (
+                                            <div className="text-gray-500">Loading more...</div>
+                                        )}
+                                        {!hasMore && data.length > 0 && (
+                                            <div className="text-gray-500">{noMoreMessage}</div>
+                                        )}
+                                    </div>
                                 </td>
                             </tr>
                         )}

--- a/src/hooks/useInfiniteAdvocates.ts
+++ b/src/hooks/useInfiniteAdvocates.ts
@@ -1,0 +1,19 @@
+import { useInfiniteApiQuery } from '@/hooks/useInfiniteApiQuery';
+import { Advocate } from '../types';
+
+interface UseInfiniteAdvocatesParams {
+  limit?: number;
+  enabled?: boolean;
+}
+
+export const useInfiniteAdvocates = ({
+  limit = 100,
+  enabled = true,
+}: UseInfiniteAdvocatesParams = {}) => {
+  return useInfiniteApiQuery<Advocate>({
+    queryKey: ['advocates', 'infinite'],
+    endpoint: '/api/advocates',
+    limit,
+    enabled,
+  });
+};

--- a/src/hooks/useInfiniteApiQuery.ts
+++ b/src/hooks/useInfiniteApiQuery.ts
@@ -1,0 +1,50 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { PaginatedResponse } from '../types';
+
+interface UseInfiniteApiQueryParams<T> {
+  queryKey: (string | Record<string, any>)[];
+  endpoint: string;
+  limit?: number;
+  enabled?: boolean;
+}
+
+interface FetchPageParams {
+  pageParam: string | null;
+  limit: number;
+  endpoint: string;
+}
+
+const fetchPage = async <T>({
+  pageParam,
+  limit,
+  endpoint
+}: FetchPageParams): Promise<PaginatedResponse<T>> => {
+  const params = new URLSearchParams();
+
+  params.append('limit', limit.toString());
+  if (pageParam) params.append('cursor', pageParam);
+
+  const response = await fetch(`${endpoint}?${params}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch from ${endpoint}`);
+  }
+
+  return response.json();
+};
+
+export const useInfiniteApiQuery = <T>({
+  queryKey,
+  endpoint,
+  limit = 100,
+  enabled = true,
+}: UseInfiniteApiQueryParams<T>) => {
+  return useInfiniteQuery({
+    queryKey: [...queryKey, { limit }],
+    queryFn: ({ pageParam }: { pageParam: string | null }) =>
+      fetchPage<T>({ pageParam, limit, endpoint }),
+    getNextPageParam: (lastPage) => lastPage.pagination.nextCursor,
+    initialPageParam: null as string | null,
+    enabled,
+  });
+};


### PR DESCRIPTION
- Created reusable useInfiniteApiQuery for all paginated endpoints
- Created useInfiniteAdvocates using generic hook for paginated advocates queries
- Table scrolls within page bounds with sticky headers